### PR TITLE
includes: fakemeta -> fakemeta_util

### DIFF
--- a/src/scripts/kreedz/kz_spec.sma
+++ b/src/scripts/kreedz/kz_spec.sma
@@ -1,7 +1,7 @@
 #include <amxmodx>
 #include <cstrike>
 #include <fun>
-#include <fakemeta>
+#include <fakemeta_util>
 #include <hamsandwich>
 #include <reapi>
 


### PR DESCRIPTION
without fakemeta_util hlds will crash when you go spectator (missing constants or so)